### PR TITLE
Fix bug where calling .length on ByteBuffer.toBuffer() in a browser returns undefined

### DIFF
--- a/js.js
+++ b/js.js
@@ -156,7 +156,7 @@ exports.generate = function(schema) {
           } else {
             type = TYPE_SIZE_N;
             before = 'var nested = ' + package + '[' + quote('encode' + field.type) + '](value)';
-            write = buffer + '.writeVarint32(nested.length), ' + buffer + '.append(nested)';
+            write = buffer + '.writeVarint32(nested.byteLength), ' + buffer + '.append(nested)';
           }
           break;
         }


### PR DESCRIPTION
I'm trying to run `pbjs` in Chrome and ran into a crash in generated code where `.length` is undefined on a value returned from `ByteBuffer.toBuffer()`.

<img width="471" alt="screen shot 2017-05-02 at 10 58 19 pm" src="https://cloud.githubusercontent.com/assets/945937/25649512/f0be907c-2f8a-11e7-87ef-1489e8d9f0b5.png">

I don't know enough about the internals of `ByteBuffer` to know if this is the right fix.

## Research

I tried to access `.length` as described above in `bytebuffer` version 5.0.1. in node and in a browser.

In node...

```
> (new (require('bytebuffer'))(undefined, true)).toBuffer().length
16
```

In a browser...

```
(new ByteBuffer(undefined, true)).toBuffer().length
undefined
```

But calling `.byteLength` works...

```
(new ByteBuffer(undefined, true)).toBuffer().byteLength
16
```

## Tests

Tests still pass after this change. Couldn't think of a good way to write a new one. Ideally the existing tests would run in a browser (or emulated browser) but I didn't feel like setting that up :-)