### PR TITLE
remove .compile to avoid schema.toJavaScript function is not found error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,7 @@ if (!process.argv.slice(2).length) {
 }
 
 var contents = fs.readFileSync(commander.args[0], 'utf8');
-var schema = index.parseSchema(contents).compile();
+var schema = index.parseSchema(contents);
 
 // Generate JavaScript code
 if (commander.js) {


### PR DESCRIPTION
When executing `pbjs test.proto --js=test.js`, I would receive `schema.toJavaScript is not a function` error. This commit fixes the error and passes all test case.