### PR TITLE
add encoder/decoder map generate

### DIFF
--- a/generate.ts
+++ b/generate.ts
@@ -980,5 +980,18 @@ export function generate(schema: Schema, options?: Options): string {
   lines.push(`}`);
   lines.push(``);
 
+  lines.push(`${codeForEnumExport('encoder')}${ts(`{ [key: string]: Function }`)} = {`);
+  for (const def of schema.messages) {
+      lines.push(`  ${def.name}: ${prefix}encode${def.name},`);
+  }
+  lines.push(`};`);
+  lines.push('');
+
+  lines.push(`${codeForEnumExport('decoder')}${ts(`{ [key: string]: Function }`)} = {`);
+  for (const def of schema.messages) {
+      lines.push(`  ${def.name}: ${prefix}decode${def.name},`);
+  }
+  lines.push(`};`);
+  lines.push('');
   return lines.join('\n');
 }

--- a/generate.ts
+++ b/generate.ts
@@ -47,7 +47,9 @@ export function generate(schema: Schema, options?: Options): string {
   function codeForEnumExport(name: string): string {
     return es6 ? `export const ${name}` : `${pkg}.${name}`;
   }
-
+  if (typescript) {
+    lines.push(`namespace ${schema.package} {`);
+  }
   for (const def of schema.enums) {
     const prefix = def.name + '_';
     const items: string[] = [];
@@ -993,5 +995,8 @@ export function generate(schema: Schema, options?: Options): string {
   }
   lines.push(`};`);
   lines.push('');
+  if (typescript) {
+    lines.push(`}`);
+  }
   return lines.join('\n');
 }


### PR DESCRIPTION
For some reasons, we need to dynamically decode some structures, like the following:

```js
const schema = pbjs.parseSchema(`
  message Demo {
    optional int32 x = 1;
    optional float y = 2;
  }
`).compile();

const buffer = schema.encode("Demo",{x: 1, y: 2});
console.log(buffer);

const message = schema.decode("Demo", buffer);
console.log(message);
```
So I added two maps, mapping the names of the structures to the encoder and decoder functions.

